### PR TITLE
Improve kernel version formatting

### DIFF
--- a/src/logs.rs
+++ b/src/logs.rs
@@ -19,7 +19,8 @@ pub async fn generate(home: &str) -> anyhow::Result<String> {
         let data = fomat_macros::fomat! {
             "System76 Model: " (info.model_and_version) "\n"
             "OS Version: " (info.operating_system) "\n"
-            "Kernel Version: " (info.kernel) "\n"
+            "Kernel Version: " (info.kernel_version) "\n"
+            "Kernel Revision: " (info.kernel_revision) "\n"
         };
 
         let mut file = AsyncFile::from(file);


### PR DESCRIPTION
As I mentioned in the [G-C-C PR discussion](https://github.com/pop-os/gnome-control-center/pull/208), the point of the `systeminfo.txt` file is to give support a quick at-a-glance overview of the system.

This PR changes the kernel version formatting to be simpler and more in line with how the System76 Driver app formatted it. Including less unnecessary details makes it easier to spot and compare quickly. If any of the other info is ever actually needed, it can be found in dmesg.

Current system76-driver output:
![1](https://user-images.githubusercontent.com/7199422/156268482-f25dd5d7-4829-4a46-b80e-f10327cc7258.png)

Current pop-support output:
![2](https://user-images.githubusercontent.com/7199422/156268484-c753ae1c-0f0c-4635-998c-eaa7754176b3.png)

New pop-support output with this PR:
![3](https://user-images.githubusercontent.com/7199422/156268488-b5550b38-9923-43c3-ab17-a7a10395de82.png)

Parsing the strings was a little convoluted, so feel free to make suggestions or revisions if there's a better way to do this. (I considered parsing `/proc/version` instead of going back to the `uname` command, but that would have required more logic to make sure the right fields are always shown compared with letting uname do some of the work.)