### PR TITLE
Correct Homepage URL

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends:
   libgtk-3-dev,
   pkg-config,
 Standards-Version: 4.3.0
-Homepage: https://github.com/pop-os/pop-support-panel
+Homepage: https://github.com/pop-os/support-panel
 
 Package: libpop-support-panel
 Architecture: amd64 arm64


### PR DESCRIPTION
Noticed in apt info that the homepage led to a broken link, corrected to what it appears it should be.