### PR TITLE
Add and adjust system log reports

### DIFF
--- a/src/logs.rs
+++ b/src/logs.rs
@@ -35,7 +35,7 @@ pub async fn generate(home: &str) -> anyhow::Result<String> {
     let temp = tempdir.path();
 
     let _ = futures::join!(
-        command("df", &["-h"], temp, "df"),
+        command("df", &["-h"], temp, "free-disk-space"),
         command("dmesg", &[], temp, "dmesg"),
         command("dmidecode", &[], temp, "dmidecode"),
         command("efibootmgr", &["-v"], temp, "efibootmgr"),
@@ -49,12 +49,12 @@ pub async fn generate(home: &str) -> anyhow::Result<String> {
             temp,
             "lsblk"
         ),
-        command("last", &[], temp, "last"),
+        command("last", &[], temp, "reboot-history"),
         command("lspci", &["-vv"], temp, "lspci"),
         command("lsusb", &["-vv"], temp, "lsusb"),
         command("lsmod", &[], temp, "lsmod"),
         command("sensors", &[], temp, "sensors"),
-        command("systemd-analyze", &["blame"], temp, "systemd-blame"),
+        command("systemd-analyze", &["blame"], temp, "boot-process-times"),
         command("upower", &["-d"], temp, "upower"),
         command("uptime", &[], temp, "uptime"),
         command("xinput", &[], temp, "xinput"),

--- a/src/support_info.rs
+++ b/src/support_info.rs
@@ -49,11 +49,11 @@ impl SupportInfo {
             if let Ok(mut name) = product_name.as_deref() {
                 name = name.trim();
 
-                if !name.is_empty() && name != sys_vendor  {
+                if !name.is_empty() && name != sys_vendor {
                     // Ensure that the name does not contain the vendor.
                     name = match name.strip_prefix(sys_vendor) {
                         Some(stripped) => stripped.trim(),
-                        None => name
+                        None => name,
                     };
 
                     strcat!(&mut model_and_version, " " name);
@@ -63,9 +63,7 @@ impl SupportInfo {
                     version = version.trim();
 
                     // These have bogus values for their version.
-                    const IGNORE_PRODUCTS: &[&str] = &[
-                        "Dev One"
-                    ];
+                    const IGNORE_PRODUCTS: &[&str] = &["Dev One"];
 
                     if !version.is_empty() && !IGNORE_PRODUCTS.contains(&name) {
                         strcat!(&mut model_and_version, " (" version.trim() ")");

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -15,9 +15,7 @@ impl Vendor {
             #[allow(clippy::single_match)]
             match sys_vendor.trim() {
                 "HP" => {
-                    if let Ok(version) =
-                        read_to_string("/sys/devices/virtual/dmi/id/board_name")
-                    {
+                    if let Ok(version) = read_to_string("/sys/devices/virtual/dmi/id/board_name") {
                         match version.trim() {
                             "8A78" => return Some(Vendor::Hp),
                             _ => (),


### PR DESCRIPTION
This commit does several things:
* It changes the `command` function to allow specifying the filename, instead of just using the same text as the shell comamnd.
* It adds the `gz` extension back to the two `apt` logs that are gzipped so they stop being opened incorrectly in a text editor.
* It adjusts the parameters for `lsblk` to include more useful information and remove the less useful info.
* It adds the output from `lsmod`, `last`, `efibootmgr`, `xinput`, and `systemd-analyze blame`, and adds `/etc/kernelstub/configuration` and `/etc/cryttab` to the files copied to the logs.
* `cargo +nightly fmt` has been run on the whole tree, modifying some other files in addition to `logs.rs` to pass the CI checks.

This is based on the kind of info we sometimes have to ask customers for in tickets that isn't already in the logs. The additional parameter to the `command` function allows us to use things like `systemd-analyze` which has many different kinds of output, and know what's actually in the file by giving it a descriptive filename.